### PR TITLE
Fix the ability to use autolinks

### DIFF
--- a/sphinx_mdinclude/render.py
+++ b/sphinx_mdinclude/render.py
@@ -190,15 +190,7 @@ class RestRenderer(BaseRenderer):
         """
         return text
 
-    def autolink(self, link, is_email=False):
-        """Rendering a given link or email address.
-
-        :param link: link content or email address.
-        :param is_email: whether this is an email or not.
-        """
-        return link
-
-    def link(self, link, text, title):
+    def link(self, link, text, title=None):
         """Rendering a given link with content and title.
 
         :param link: href link for ``<a>`` tag.

--- a/sphinx_mdinclude/sphinx.py
+++ b/sphinx_mdinclude/sphinx.py
@@ -8,6 +8,7 @@ import os.path
 from docutils import io, nodes, statemachine, utils
 from docutils.core import ErrorString
 from docutils.parsers import rst
+from docutils.parsers.rst import directives as rst_directives
 from docutils.utils import SafeString
 
 from . import RestMarkdown
@@ -59,7 +60,7 @@ class MdInclude(rst.Directive):
             self.lineno - self.state_machine.input_offset - 1
         )
         source_dir = os.path.dirname(os.path.abspath(source))
-        path = rst.directives.path(self.arguments[0])
+        path = rst_directives.path(self.arguments[0])
         path = os.path.normpath(os.path.join(source_dir, path))
         path = utils.relative_path(None, path)
         path = nodes.reprunicode(path)

--- a/sphinx_mdinclude/tests/test_renderer.py
+++ b/sphinx_mdinclude/tests/test_renderer.py
@@ -132,7 +132,7 @@ class TestInlineMarkdown(RendererTestBase):
         out = self.conv(src)
         self.assertEqual(out.replace("\n", ""), "**a**")
 
-    def test_autolink(self):
+    def test_not_an_autolink(self):
         src = "link to http://example.com/ in sentence."
         out = self.conv(src)
         self.assertEqual(out, "\n" + src + "\n")
@@ -146,6 +146,11 @@ class TestInlineMarkdown(RendererTestBase):
         src = "this is an [anchor link](#anchor)."
         out = self.conv_no_check(src)
         self.assertEqual(out, "\nthis is an :ref:`anchor link <anchor>`.\n")
+
+    def test_autolink(self):
+        src = "link <http://example.com>"
+        out = self.conv(src)
+        self.assertEqual(out, "\nlink `http://example.com <http://example.com>`_\n")
 
     def test_link_title(self):
         src = 'this is a [link](http://example.com/ "example").'


### PR DESCRIPTION
### Description

Fix the ability to use autolinks (links with `<>` around them).  Test included.  I poked around at trying to make flake8 or mypy complain about the subclass using different args and in a few minutes of trying, could not.  Did notice one import-related problem and fixed that as well.

Fixes: #2 
