### PR TITLE
Get rid of deprecation warnings

### DIFF
--- a/sphinx_mdinclude/sphinx.py
+++ b/sphinx_mdinclude/sphinx.py
@@ -10,7 +10,9 @@ from docutils.parsers import rst
 from docutils.parsers.rst import directives as rst_directives
 
 try:  # new
-    from docutils.io import error_string as ErrorString
+    from docutils.io import (  # type: ignore  # typeshed  #8716
+        error_string as ErrorString,
+    )
 
     SafeString = str
 except ImportError:  # old

--- a/sphinx_mdinclude/sphinx.py
+++ b/sphinx_mdinclude/sphinx.py
@@ -10,7 +10,8 @@ from docutils.parsers import rst
 from docutils.parsers.rst import directives as rst_directives
 
 try:  # new
-    from docutils.utils.error_reporting import ErrorString, SafeString
+    from docutils.io import error_string as ErrorString
+    SafeString = str
 except ImportError:  # old
     from docutils.core import ErrorString  # type: ignore
     from docutils.utils import SafeString  # type: ignore

--- a/sphinx_mdinclude/sphinx.py
+++ b/sphinx_mdinclude/sphinx.py
@@ -11,6 +11,7 @@ from docutils.parsers.rst import directives as rst_directives
 
 try:  # new
     from docutils.io import error_string as ErrorString
+
     SafeString = str
 except ImportError:  # old
     from docutils.core import ErrorString  # type: ignore


### PR DESCRIPTION
### Description

In case you are interested: This gets rid of the deprecation warnings in docutils

Fixes: #
