### PR TITLE
Fixing mistune dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
 readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
-    "mistune >= 2.0",
+    "mistune >=2.0,<3.0",
     "docutils >=0.16,<1.0",
     "pygments >= 2.8",
 ]


### PR DESCRIPTION
### Description

This is a follow-up to #13.
Full description of the issue: https://github.com/amyreese/sphinx-mdinclude/issues/12
The fix presented here is to restrict `mistune` dependency to only `2.*` and not just `>=2`.

Fixes: #12 

### Changes made

- `mistune` dependency is now `2.*`;