### PR TITLE
Update for mistune v3.x (fixes #22)

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -7,11 +7,11 @@ Source code is [here](https://github.com/omnilib/sphinx-mdinclude/raw/main/docs/
 
 A **strong**, *emphasis*, ~~deleted~~, `code with single-backtick`,
 ``code with two-backticks``, ```code can include multiple (``) backticks```,
-:code:`reST's code role`, and <del>inline html</del>delete.
+:code:`reST's code role`, and <del>inline html</del> delete.
 
 ### Link
 
-Auto link to http://example.com/.
+Auto link to <http://example.com/>.
 
 Link to [example.com](http://example.com/) in markdown.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = ["Markdown", "reStructuredText", "sphinx-extension"]
 dynamic = ["version", "description"]
 requires-python = ">=3.8"
 dependencies = [
-    "mistune >=2.0,<3.0",
+    "mistune >=3.0,<4.0",
     "docutils >=0.16,<1.0",
     "pygments >= 2.8",
 ]
@@ -34,7 +34,7 @@ dependencies = [
 dev = [
     "docutils==0.20.1; python_version < '3.9'",
     "docutils==0.21.1; python_version >= '3.9'",
-    "mistune==2.0.4",
+    "mistune==3.0.2",
 
     "attribution==1.6.2",
     "black==24.4.0",

--- a/sphinx_mdinclude/parse.py
+++ b/sphinx_mdinclude/parse.py
@@ -1,4 +1,3 @@
-import re
 from typing import Any, Dict, Match, Tuple
 
 from mistune import BlockParser, InlineParser
@@ -13,13 +12,15 @@ Element = Tuple[str, ...]
 
 class RestBlockParser(BlockParser):
     SPECIFICATION = BlockParser.SPECIFICATION.copy()
-    SPECIFICATION |= {
-        "directive": r"(?ms:^(?P<directive_1> *\.\..*?)\n(?=\S))",
-        "oneline_directive": r"(?ms:^(?P<directive_2> *\.\..*?)$)",
-        "rest_code_block": r"(?m:^::\s*$)",
-    }
+    SPECIFICATION.update(
+        {
+            "directive": r"(?ms:^(?P<directive_1> *\.\..*?)\n(?=\S))",
+            "oneline_directive": r"(?ms:^(?P<directive_2> *\.\..*?)$)",
+            "rest_code_block": r"(?m:^::\s*$)",
+        }
+    )
 
-    DEFAULT_RULES = BlockParser.DEFAULT_RULES + (
+    DEFAULT_RULES = BlockParser.DEFAULT_RULES + (  # type: ignore[has-type]
         "directive",
         "oneline_directive",
         "rest_code_block",
@@ -54,13 +55,15 @@ class RestInlineParser(InlineParser):
     )
 
     SPECIFICATION = InlineParser.SPECIFICATION.copy()
-    SPECIFICATION |= {
-        "inline_html": INLINE_HTML,
-        "inline_math": r"`\$(?P<math_1>.*?)\$`",
-        "rest_role": r":.*?:`.*?`|`[^`]+`:.*?:",
-        "rest_link": r"`[^`]*?`_",
-        "eol_literal_marker": r"(?P<eol_space>\s+)?::\s*$",
-    }
+    SPECIFICATION.update(
+        {
+            "inline_html": INLINE_HTML,
+            "inline_math": r"`\$(?P<math_1>.*?)\$`",
+            "rest_role": r":.*?:`.*?`|`[^`]+`:.*?:",
+            "rest_link": r"`[^`]*?`_",
+            "eol_literal_marker": r"(?P<eol_space>\s+)?::\s*$",
+        }
+    )
 
     # Order is important: need these rules to be checked before the
     # default rules
@@ -69,7 +72,7 @@ class RestInlineParser(InlineParser):
         "rest_role",
         "rest_link",
         "eol_literal_marker",
-    ) + InlineParser.DEFAULT_RULES
+    ) + InlineParser.DEFAULT_RULES  # type: ignore[has-type]
 
     def parse_rest_role(self, m: Match, state: InlineState) -> int:
         """Pass through rest role."""

--- a/sphinx_mdinclude/parse.py
+++ b/sphinx_mdinclude/parse.py
@@ -2,6 +2,7 @@ import re
 from typing import Any, Dict, Match, Tuple
 
 from mistune import BlockParser, InlineParser
+from mistune.core import BlockState, InlineState
 from mistune.inline_parser import HTML_ATTRIBUTES, HTML_TAGNAME
 
 
@@ -11,53 +12,36 @@ Element = Tuple[str, ...]
 
 
 class RestBlockParser(BlockParser):
-    DIRECTIVE = re.compile(
-        r"^( *\.\..*?)\n(?=\S)",
-        re.DOTALL | re.MULTILINE,
-    )
-    ONELINE_DIRECTIVE = re.compile(
-        r"^( *\.\..*?)$",
-        re.DOTALL | re.MULTILINE,
-    )
-    REST_CODE_BLOCK = re.compile(
-        r"^::\s*$",
-        re.DOTALL | re.MULTILINE,
-    )
+    SPECIFICATION = BlockParser.SPECIFICATION.copy()
+    SPECIFICATION |= {
+        "directive": r"(?ms:^(?P<directive_1> *\.\..*?)\n(?=\S))",
+        "oneline_directive": r"(?ms:^(?P<directive_2> *\.\..*?)$)",
+        "rest_code_block": r"(?m:^::\s*$)",
+    }
 
-    RULE_NAMES = BlockParser.RULE_NAMES + (
+    DEFAULT_RULES = BlockParser.DEFAULT_RULES + (
         "directive",
         "oneline_directive",
         "rest_code_block",
     )
 
-    def parse_directive(self, match: Match, state: State) -> Token:
-        return {"type": "directive", "text": match.group(1)}
+    def parse_directive(self, m: Match, state: BlockState) -> int:
+        state.append_token({"type": "directive", "raw": m.group("directive_1")})
+        return m.end()
 
-    def parse_oneline_directive(self, match: Match, state: State) -> Token:
+    def parse_oneline_directive(self, m: Match, state: BlockState) -> int:
         # reuse directive output
-        return {"type": "directive", "text": match.group(1)}
+        state.append_token({"type": "directive", "raw": m.group("directive_2")})
+        # $ does not count '\n'
+        return m.end() + 1
 
-    def parse_rest_code_block(self, match: Match, state: State) -> Token:
-        return {"type": "rest_code_block", "text": ""}
+    def parse_rest_code_block(self, m: Match, state: BlockState) -> int:
+        state.append_token({"type": "rest_code_block", "text": ""})
+        # $ does not count '\n'
+        return m.end() + 1
 
 
 class RestInlineParser(InlineParser):
-    REST_ROLE = r":.*?:`.*?`|`[^`]+`:.*?:"
-    REST_LINK = r"`[^`]*?`_"
-    INLINE_MATH = r"`\$((.*?)\$`)"
-    EOL_LITERAL_MARKER = r"(\s+)?::\s*$"
-
-    # add colon and space as special text
-    TEXT = r"^[\s\S]+?(?=[\\<!\[:_*`~ ]|https?://| {2,}\n|$)"
-
-    # __word__ or **word**
-    DOUBLE_EMPHASIS = r"^([_*]){2}(?P<text>[\s\S]+?)\1{2}(?!\1)"
-    # _word_ or *word*
-    EMPHASIS = (
-        r"^\b_((?:__|[^_])+?)_\b",  # _word_
-        r"^\*(?P<text>(?:\*\*|[^\*])+?)\*(?!\*)",  # *word*
-    )
-
     # make inline_html span open/contents/close instead of just a single tag
     INLINE_HTML = (
         r"(?<!\\)<" + HTML_TAGNAME + HTML_ATTRIBUTES + r"\s*>"  # open tag
@@ -69,40 +53,42 @@ class RestInlineParser(InlineParser):
         r"(?<!\\)<!\[CDATA[\s\S]+?\]\]>"  # cdata
     )
 
-    RULE_NAMES = (
+    SPECIFICATION = InlineParser.SPECIFICATION.copy()
+    SPECIFICATION |= {
+        "inline_html": INLINE_HTML,
+        "inline_math": r"`\$(?P<math_1>.*?)\$`",
+        "rest_role": r":.*?:`.*?`|`[^`]+`:.*?:",
+        "rest_link": r"`[^`]*?`_",
+        "eol_literal_marker": r"(?P<eol_space>\s+)?::\s*$",
+    }
+
+    # Order is important: need these rules to be checked before the
+    # default rules
+    DEFAULT_RULES = (
         "inline_math",
-        # "image_link",
         "rest_role",
         "rest_link",
         "eol_literal_marker",
-    ) + InlineParser.RULE_NAMES
+    ) + InlineParser.DEFAULT_RULES
 
-    def parse_double_emphasis(self, match: Match, state: State) -> Element:
-        # may include code span
-        return "double_emphasis", match.group("text")
-
-    def parse_emphasis(self, match: Match, state: State) -> Element:
-        # may include code span
-        return "emphasis", match.group("text") or match.group(1)
-
-    def parse_image_link(self, match: Match, state: State) -> Element:
+    def parse_rest_role(self, m: Match, state: InlineState) -> int:
         """Pass through rest role."""
-        alt, src, target = match.groups()
-        return "image_link", src, target, alt
+        state.append_token({"type": "rest_role", "raw": m.group(0)})
+        return m.end()
 
-    def parse_rest_role(self, match: Match, state: State) -> Element:
-        """Pass through rest role."""
-        return "rest_role", match.group(0)
-
-    def parse_rest_link(self, match: Match, state: State) -> Element:
+    def parse_rest_link(self, m: Match, state: InlineState) -> int:
         """Pass through rest link."""
-        return "rest_link", match.group(0)
+        state.append_token({"type": "rest_link", "raw": m.group(0)})
+        return m.end()
 
-    def parse_inline_math(self, match: Match, state: State) -> Element:
-        """Pass through rest link."""
-        return "inline_math", match.group(2)
+    def parse_inline_math(self, m: Match, state: InlineState) -> int:
+        """Pass through inline math."""
+        state.append_token({"type": "inline_math", "raw": m.group("math_1")})
+        return m.end()
 
-    def parse_eol_literal_marker(self, match: Match, state: State) -> Element:
+    def parse_eol_literal_marker(self, m: Match, state: InlineState) -> int:
         """Pass through rest link."""
-        marker = ":" if match.group(1) is None else ""
-        return "eol_literal_marker", marker
+        marker = ":" if m.group("eol_space") is None else ""
+        state.append_token({"type": "eol_literal_marker", "raw": marker})
+        # $ does not count '\n'
+        return m.end() + 1

--- a/sphinx_mdinclude/render.py
+++ b/sphinx_mdinclude/render.py
@@ -2,16 +2,16 @@ import re
 import textwrap
 from functools import partial
 from importlib import import_module
+from typing import Any, Dict
 
 from docutils.utils import column_width
 from mistune import Markdown
-from mistune.plugins import _plugins
 from mistune.core import BaseRenderer
+from mistune.plugins import _plugins
 
 from .parse import RestBlockParser, RestInlineParser
 
-_cached_modules = {}
-
+CACHED_MODULES: Dict[str, Any] = {}
 DEFAULT_PLUGINS = ["strikethrough", "footnotes", "table"]
 
 PROLOG = """\
@@ -197,11 +197,7 @@ class RestRenderer(BaseRenderer):
 
         :param text: text content for inline code.
         """
-        cannot_inline = (
-            "``" in text or
-            text[0] in [" ", "`"] or
-            text[-1] in [" ", "`"]
-        )
+        cannot_inline = "``" in text or text[0] in [" ", "`"] or text[-1] in [" ", "`"]
         if cannot_inline:
             # actually, docutils split spaces in literal
             return self._raw_html(
@@ -361,8 +357,8 @@ class RestMarkdown(Markdown):
         plugins_str = plugins or [_plugins[p] for p in DEFAULT_PLUGINS]
         plugins = []
         for plugin_str in plugins_str:
-            if plugin_str in _cached_modules:
-                plugins.append(_cached_modules[plugin_str])
+            if plugin_str in CACHED_MODULES:
+                plugins.append(CACHED_MODULES[plugin_str])
             else:
                 if isinstance(plugin_str, str):
                     module_path, func_name = plugin_str.rsplit(".", 1)
@@ -371,7 +367,7 @@ class RestMarkdown(Markdown):
                 else:
                     # Presumably a function has been passed
                     plugin = plugin_str
-                _cached_modules[plugin_str] = plugin
+                CACHED_MODULES[plugin_str] = plugin
                 plugins.append(plugin)
 
         super().__init__(renderer, block=block, inline=inline, plugins=plugins)

--- a/sphinx_mdinclude/render.py
+++ b/sphinx_mdinclude/render.py
@@ -1,13 +1,16 @@
 import re
 import textwrap
 from functools import partial
+from importlib import import_module
 
 from docutils.utils import column_width
 from mistune import Markdown
-from mistune.plugins import PLUGINS
-from mistune.renderers import BaseRenderer
+from mistune.plugins import _plugins
+from mistune.core import BaseRenderer
 
 from .parse import RestBlockParser, RestInlineParser
+
+_cached_modules = {}
 
 DEFAULT_PLUGINS = ["strikethrough", "footnotes", "table"]
 
@@ -35,6 +38,36 @@ class RestRenderer(BaseRenderer):
         self._indent_block = partial(textwrap.indent, prefix=self.indent)
         super().__init__(*args, **kwargs)
 
+    def render_token(self, token, state):
+        # based on mistune 3.0.2, mistune/renderers/html.py
+        func = self._get_method(token["type"])
+        attrs = token.get("attrs")
+        style = token.get("style")
+
+        if "raw" in token:
+            text = token["raw"]
+        elif "children" in token:
+            text = self.render_tokens(token["children"], state)
+        else:
+            if attrs:
+                return func(**attrs)
+            else:
+                return func()
+
+        # We have to special-case block_code, as it needs to know the
+        # style as well to determine whether to add a blank line at the
+        # end (so as to retain the original behaviour)
+        if token["type"] == "block_code":
+            if attrs:
+                return func(text, style=style, **attrs)
+            else:
+                return func(text, style=style)
+
+        if attrs:
+            return func(text, **attrs)
+        else:
+            return func(text)
+
     def finalize(self, data):
         return "".join(data)
 
@@ -42,15 +75,16 @@ class RestRenderer(BaseRenderer):
         self._include_raw_html = True
         return r":raw-html-md:`{}`".format(html)
 
-    def block_code(self, code, lang=None):
-        if lang == "math":
+    def block_code(self, code, style, info=None):
+        if info == "math":
             first_line = "\n.. math::\n\n"
-        elif lang:
-            first_line = "\n.. code-block:: {}\n\n".format(lang)
+        elif info:
+            first_line = "\n.. code-block:: {}\n\n".format(info)
         else:
             # first_line = "\n::\n\n"
             first_line = "\n.. code-block::\n\n"
-        return first_line + self._indent_block(code)
+        newline = "\n" if style == "indent" else ""
+        return first_line + self._indent_block(code + newline)
 
     def block_quote(self, text):
         # text includes some empty line
@@ -64,14 +98,14 @@ class RestRenderer(BaseRenderer):
 
         :param html: text content of the html snippet.
         """
-        return "\n\n.. raw:: html\n\n" + self._indent_block(html) + "\n\n"
+        return "\n\n.. raw:: html\n\n" + self._indent_block(html) + "\n"
 
-    def heading(self, text, level, raw=None):
+    def heading(self, text, level, **attrs):
         """Rendering header/heading tags like ``<h1>`` ``<h2>``.
 
         :param text: rendered text content for the header.
         :param level: a number for the header level, for example: 1.
-        :param raw: raw text content of the header.
+        :param attrs: other attributes of the header.
         """
         return "\n{0}\n{1}\n".format(text, self.hmarks[level] * column_width(text))
 
@@ -79,21 +113,22 @@ class RestRenderer(BaseRenderer):
         """Rendering method for ``<hr>`` tag."""
         return "\n----\n"
 
-    def list(self, body, ordered, level, start):
+    def list(self, text, ordered, **attrs):
         """Rendering list tags like ``<ul>`` and ``<ol>``.
 
-        :param body: body contents of the list.
+        :param text: body contents of the list.
         :param ordered: whether this list is ordered or not.
+        :param attrs: other attributes of the list.
         """
         mark = "#. " if ordered else "* "
-        lines = body.splitlines()
+        lines = text.splitlines()
         for i, line in enumerate(lines):
             if line and not line.startswith(self.list_marker):
                 lines[i] = " " * len(mark) + line
         result = "\n{}\n".format("\n".join(lines)).replace(self.list_marker, mark)
         return result
 
-    def list_item(self, text, level):
+    def list_item(self, text):
         """Rendering list item snippet. Like ``<li>``."""
         return "\n" + self.list_marker + text
 
@@ -131,12 +166,12 @@ class RestRenderer(BaseRenderer):
                 clist.append("  " + c)
         return "\n".join(clist) + "\n"
 
-    def table_cell(self, content, align=None, is_head=False):
+    def table_cell(self, content, align=None, head=False):
         """Rendering a table cell. Like ``<th>`` ``<td>``.
 
         :param content: content of current table cell.
-        :param header: whether this is header or not.
         :param align: align of current table cell.
+        :param head: whether this is header or not.
         """
         return "- " + content + "\n"
 
@@ -162,19 +197,28 @@ class RestRenderer(BaseRenderer):
 
         :param text: text content for inline code.
         """
-        if "``" not in text:
-            return r"``{}``".format(text)
-        else:
+        cannot_inline = (
+            "``" in text or
+            text[0] in [" ", "`"] or
+            text[-1] in [" ", "`"]
+        )
+        if cannot_inline:
             # actually, docutils split spaces in literal
             return self._raw_html(
                 '<code class="docutils literal">'
                 '<span class="pre">{}</span>'
                 "</code>".format(text.replace("`", "&#96;"))
             )
+        else:
+            return r"``{}``".format(text)
 
     def linebreak(self):
         """Rendering line break like ``<br>``."""
         return " " + self._raw_html("<br />") + "\n"
+
+    def softbreak(self):
+        """Rendering soft line break."""
+        return "\n"
 
     def strikethrough(self, text):
         """Rendering ~~strikethrough~~ text.
@@ -190,47 +234,47 @@ class RestRenderer(BaseRenderer):
         """
         return text
 
-    def link(self, link, text, title=None):
+    def link(self, text, url, title=None):
         """Rendering a given link with content and title.
 
-        :param link: href link for ``<a>`` tag.
-        :param title: title content for `title` attribute.
         :param text: text content for description.
+        :param url: URL for ``<a>`` tag.
+        :param title: title content for `title` attribute.
         """
         if text.startswith("\n.. image::"):
-            text = re.sub(r":target: (.*)\n", f":target: {link}\n", text)
+            text = re.sub(r":target: (.*)\n", f":target: {url}\n", text)
             return text
 
         underscore = "_"
         if title:
             return self._raw_html(
-                '<a href="{link}" title="{title}">{text}</a>'.format(
-                    link=link, title=title, text=text
+                '<a href="{url}" title="{title}">{text}</a>'.format(
+                    url=url, title=title, text=text
                 )
             )
-        if link.startswith("#"):
-            target = link[1:]
+        if url.startswith("#"):
+            target = url[1:]
             return r":ref:`{text} <{target}>`".format(target=target, text=text)
 
         return r"`{text} <{target}>`{underscore}".format(
-            target=link, text=text, underscore=underscore
+            target=url, text=text, underscore=underscore
         )
 
-    def image(self, src, alt, title):
+    def image(self, text, url, title=None):
         """Rendering a image with title and text.
 
-        :param src: source link of the image.
-        :param title: title text of the image.
         :param text: alt text of the image.
+        :param url: source link of the image.
+        :param title: title text of the image.
         """
         # rst does not support title option
         # and I couldn't find title attribute in HTML standard
         return "\n".join(
             [
                 "",
-                ".. image:: {}".format(src),
-                "   :target: {}".format(src),
-                "   :alt: {}".format(alt),
+                ".. image:: {}".format(url),
+                "   :target: {}".format(url),
+                "   :alt: {}".format(text),
                 "",
             ]
         )
@@ -285,19 +329,19 @@ class RestRenderer(BaseRenderer):
 
     """Below outputs are for rst."""
 
-    def rest_role(self, text):
-        return text
+    def rest_role(self, raw):
+        return raw
 
-    def rest_link(self, text):
-        return text
+    def rest_link(self, raw):
+        return raw
 
-    def inline_math(self, math):
+    def inline_math(self, raw):
         """Extension of recommonmark."""
-        return r":math:`{}`".format(math)
+        return r":math:`{}`".format(raw)
 
-    def eol_literal_marker(self, marker):
+    def eol_literal_marker(self, raw):
         """Extension of recommonmark."""
-        return marker
+        return raw
 
     def directive(self, text):
         return "\n" + text
@@ -305,21 +349,38 @@ class RestRenderer(BaseRenderer):
     def rest_code_block(self, text):
         return "\n\n"
 
+    def blank_line(self):
+        return ""
+
 
 class RestMarkdown(Markdown):
     def __init__(self, renderer=None, block=None, inline=None, plugins=None, **kwargs):
         renderer = renderer or RestRenderer()
         block = block or RestBlockParser()
-        inline = inline or RestInlineParser(renderer)
-        plugins = plugins or [PLUGINS[p] for p in DEFAULT_PLUGINS]
+        inline = inline or RestInlineParser()
+        plugins_str = plugins or [_plugins[p] for p in DEFAULT_PLUGINS]
+        plugins = []
+        for plugin_str in plugins_str:
+            if plugin_str in _cached_modules:
+                plugins.append(_cached_modules[plugin_str])
+            else:
+                if isinstance(plugin_str, str):
+                    module_path, func_name = plugin_str.rsplit(".", 1)
+                    module = import_module(module_path)
+                    plugin = getattr(module, func_name)
+                else:
+                    # Presumably a function has been passed
+                    plugin = plugin_str
+                _cached_modules[plugin_str] = plugin
+                plugins.append(plugin)
 
         super().__init__(renderer, block=block, inline=inline, plugins=plugins)
 
     def parse(self, text):
-        output = super().parse(text)
+        output, state = super().parse(text)
         output = self.post_process(output)
 
-        return output
+        return output, state
 
     def post_process(self, text):
         if self.renderer._include_raw_html:

--- a/sphinx_mdinclude/tests/__init__.py
+++ b/sphinx_mdinclude/tests/__init__.py
@@ -2,7 +2,7 @@ from .test_renderer import (
     TestBasic,
     TestBlockQuote,
     TestCodeBlock,
-    TestConplexText,
+    TestComplexText,
     TestDirective,
     TestFootNote,
     TestHeading,

--- a/sphinx_mdinclude/tests/test_renderer.py
+++ b/sphinx_mdinclude/tests/test_renderer.py
@@ -108,6 +108,44 @@ class TestInlineMarkdown(RendererTestBase):
             '<span class="pre">a&#96;&#96;a</span></code>`',
         )
 
+    def test_inline_code_with_opening_space(self):
+        src = "`` `a`:role:``"
+        out = self.conv(src)
+        self.assertEqual(
+            out.strip(),
+            ".. role:: raw-html-md(raw)\n"
+            "   :format: html\n\n\n"
+            ':raw-html-md:`<code class="docutils literal">'
+            '<span class="pre"> &#96;a&#96;:role:</span></code>`',
+        )
+
+    def test_inline_code_with_closing_space(self):
+        src = "``:role:`a` ``"
+        out = self.conv(src)
+        self.assertEqual(
+            out.strip(),
+            ".. role:: raw-html-md(raw)\n"
+            "   :format: html\n\n\n"
+            ':raw-html-md:`<code class="docutils literal">'
+            '<span class="pre">:role:&#96;a&#96; </span></code>`',
+        )
+
+    def test_inline_code_with_opening_and_closing_space(self):
+        src = "`` a ``"
+        out = self.conv(src)
+        self.assertEqual(out, "\n``a``\n")
+
+    def test_inline_code_with_opening_and_closing_space_and_backtick(self):
+        src = "`` `a` ``"
+        out = self.conv(src)
+        self.assertEqual(
+            out.strip(),
+            ".. role:: raw-html-md(raw)\n"
+            "   :format: html\n\n\n"
+            ':raw-html-md:`<code class="docutils literal">'
+            '<span class="pre">&#96;a&#96;</span></code>`',
+        )
+
     def test_strikethrough(self):
         src = "~~a~~"
         self.conv(src)
@@ -642,7 +680,7 @@ class TestList(RendererTestBase):
         )
 
 
-class TestConplexText(RendererTestBase):
+class TestComplexText(RendererTestBase):
     def test_code(self):
         src = """
 some sentence
@@ -708,13 +746,13 @@ class TestFootNote(RendererTestBase):
                 [
                     "",
                     "This is a[#fn-1]_ "
-                    "footnote[#fn-2]_ ref[#fn-ref]_ with rst [#a]_.",
+                    "footnote[#fn-2]_ ref[#fn-REF]_ with rst [#a]_.",
                     "",
                     ".. [#a] note rst",  # one empty line inserted...
                     "",
                     ".. [#fn-1] note 1",
                     ".. [#fn-2] note 2",
-                    ".. [#fn-ref] note ref",
+                    ".. [#fn-REF] note ref",
                     "",
                 ]
             ),


### PR DESCRIPTION
### Description

Update sphinx_mdinclude to work with mistune v3.0.2.

Fixes: #22 

## Detailed description of PR

* `example.md`: Fix two issues: there was a missing space after a close HTML delimiter, and the auto link was just plain text.
* `pyproject.toml`: Update the mistune dependency version numbers.
* `sphinx_mdinclude/parse.py`: quite significant reworking to update to mistune 3.0.2 internals.
* `sphinx_mdinclude/render.py`: likewise.  The new `render_token` function is a bit grim, unfortunately. There's probably a nicer way to do it, but this works.  I have also fixed a small bug: in `codespan()`, if the inline code begins or ends with a space or backquote, then it cannot be rendered using double backquotes (and this broke the inclusion of `changelog.md` in the documentation).
* `sphinx_mdinclude/tests/__init__.py`: I've renamed `TestConplexText` as `TestComplexTest`.
* `sphinx_mdinclude/tests/test.rst`: I have modified this to match the output of `convert(testmd)`, where `testmd` is the content of the `test.md` file.
* `sphinx_mdinclude/tests/test_renderer.py`: four extra tests for inline code beginning/ending with spaces or quotes. Rename `TestConplexText`. In the new mistune, footnote references are all normalised to upper-case; update the expected output in `TestFootNote` to this new behaviour.
