### PR TITLE
Add new smoke tests to run converter and mdinclude directive with docutils

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,8 +29,9 @@ test:
 deps:
 	python -m pessimist --requirements= -c 'python -m sphinx_mdinclude.tests' .
 
+.PHONY: html
 html: .venv README.md docs/*.md docs/conf.py
-	source .venv/bin/activate && sphinx-build -b html docs html
+	source .venv/bin/activate && sphinx-build -ab html docs html
 
 clean:
 	rm -rf build dist html *.egg-info .mypy_cache

--- a/sphinx_mdinclude/tests/__init__.py
+++ b/sphinx_mdinclude/tests/__init__.py
@@ -12,3 +12,4 @@ from .test_renderer import (
     TestRestCode,
     TestTable,
 )
+from .test_smoke import SmokeTest

--- a/sphinx_mdinclude/tests/__main__.py
+++ b/sphinx_mdinclude/tests/__main__.py
@@ -4,4 +4,4 @@
 import unittest
 
 if __name__ == "__main__":
-    unittest.main("sphinx_mdinclude.tests", verbosity=1)
+    unittest.main("sphinx_mdinclude.tests", verbosity=2)

--- a/sphinx_mdinclude/tests/test.md
+++ b/sphinx_mdinclude/tests/test.md
@@ -2,7 +2,7 @@
 
 ## SubTitle
 
-__content__
+**content**
 
 ## サブタイトル
 

--- a/sphinx_mdinclude/tests/test.rst
+++ b/sphinx_mdinclude/tests/test.rst
@@ -20,6 +20,6 @@ Also within parentheses (:math:`x^2`) and (:math:`z^3`).
 
 .. code-block:: python
 
-    class Foo:
-        def bar(self, arg: str = "") -> int:
-            return len(arg)
+   class Foo:
+       def bar(self, arg: str = "") -> int:
+           return len(arg)

--- a/sphinx_mdinclude/tests/test_smoke.py
+++ b/sphinx_mdinclude/tests/test_smoke.py
@@ -1,0 +1,78 @@
+# Copyright Amethyst Reese
+# Licensed under the MIT License
+
+import platform
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+from textwrap import dedent
+
+from docutils.frontend import get_default_settings
+from docutils.parsers.rst import directives, Parser
+from docutils.utils import new_document
+
+from ..render import convert
+from ..sphinx import MdInclude
+
+TEST_MD = Path(__file__).parent / "test.md"
+TEST_RST = Path(__file__).parent / "test.rst"
+
+
+@dataclass
+class FakeConfig:
+    no_underscore_emphasis: bool = False
+    md_parse_relative_links: bool = False
+    md_anonymous_references: bool = False
+    md_disable_inline_math: bool = False
+
+
+@dataclass
+class FakeEnv:
+    config: FakeConfig = field(default_factory=FakeConfig)
+
+
+class SmokeTest(unittest.TestCase):
+    maxDiff = None
+
+    @unittest.skipIf(
+        platform.system() == "Windows",
+        "inconsistent column widths on Windows",
+    )
+    def test_convert(self):
+        content = TEST_MD.read_text()
+        expected = TEST_RST.read_text()
+
+        result = convert(content)
+        self.assertEqual(expected, result)
+
+    def test_mdinclude_basic(self):
+        content = dedent(
+            f"""
+            .. mdinclude:: {TEST_MD}
+
+            """
+        )
+        expected = dedent(
+            """\
+            <document source="smoke.rst">
+                <section ids="title" names="title">
+                    <title>
+                        Title
+                    <section ids="subtitle" names="subtitle">
+                        <title>
+                            SubTitle
+                        <paragraph>
+                            <strong>
+                                content
+            """
+        )
+
+        directives.register_directive("mdinclude", MdInclude)
+        parser = Parser()
+        settings = get_default_settings(Parser)
+        settings.env = FakeEnv()
+        document = new_document("smoke.rst", settings.copy())
+        parser.parse(content, document)
+
+        result = document.pformat()
+        self.assertEqual(expected, result[: len(expected)])


### PR DESCRIPTION
### Description

Adds new smoke tests to validate sphinx directive and text converter against unicode fixtures.

