### PR TITLE
Render codespans within link text.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,6 +8,7 @@ ignore =
     E2
     E3
     E4
+    E501
     W503
 max-line-length = 88
 per-file-ignores =

--- a/sphinx_mdinclude/render.py
+++ b/sphinx_mdinclude/render.py
@@ -241,6 +241,17 @@ class RestRenderer(BaseRenderer):
             text = re.sub(r":target: (.*)\n", f":target: {url}\n", text)
             return text
 
+        if text.startswith("``") and text.endswith("``"):
+            # Return raw HTML for inline code:
+            html = (
+                '<code class="docutils literal">'
+                '<span class="pre">{}</span>'
+                "</code>".format(text[2:-2].replace("`", "&#96;"))
+            )
+            return self._raw_html(
+                '<a href="{url}">{text}</a>'.format(url=url, text=html)
+            )
+
         underscore = "_"
         if title:
             return self._raw_html(

--- a/sphinx_mdinclude/tests/test_renderer.py
+++ b/sphinx_mdinclude/tests/test_renderer.py
@@ -147,6 +147,17 @@ class TestInlineMarkdown(RendererTestBase):
             '<span class="pre">&#96;a&#96;</span></code>`',
         )
 
+    def test_inline_code_within_link(self) -> None:
+        src = "[`foobar`](https://example.com)"
+        out = self.conv(src)
+        self.assertEqual(
+            out.strip(),
+            ".. role:: raw-html-md(raw)\n"
+            "   :format: html\n\n\n"
+            ':raw-html-md:`<a href="https://example.com"><code class="docutils literal">'
+            '<span class="pre">foobar</span></code></a>`',
+        )
+
     def test_strikethrough(self) -> None:
         src = "~~a~~"
         self.conv(src)


### PR DESCRIPTION
Before this PR, the following Markdown:

```md
[`foobar`](https://example.com)
```

...would be rendered in RestructuredText as:
```rst
``foobar` <https://example.com>`_
```

...which unfortunately does not parse and results in the link showing up as plain text in the output HTML.

This PR adds a special case for links whose text starts and ends with backticks, returning raw HTML instead that contains a manually-inserted `<a>` tag surrounding a `<code>` block and a `<span class="pre">`.