### PR TITLE
Fix version range for docutils dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = ["version", "description"]
 requires-python = ">=3.8"
 dependencies = [
     "mistune >=3.0,<4.0",
-    "docutils >=0.16,<1.0",
+    "docutils >=0.19,<1.0",
     "pygments >= 2.8",
     "sphinx >= 6",
 ]


### PR DESCRIPTION
### Description

Fix the version range for the `docutils` dependency as outlined in #79 since we use a function added in `0.19`.

Fixes: #79
